### PR TITLE
채팅방 업데이트

### DIFF
--- a/src/main/java/shop/dodotalk/dorundorun/DorunDorunApplication.java
+++ b/src/main/java/shop/dodotalk/dorundorun/DorunDorunApplication.java
@@ -3,9 +3,13 @@ package shop.dodotalk.dorundorun;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
+@EnableAsync
 public class DorunDorunApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/shop/dodotalk/dorundorun/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/shop/dodotalk/dorundorun/chatroom/controller/ChatRoomController.java
@@ -80,15 +80,11 @@ public class ChatRoomController {
 
 
     /*방 나가기 API*/
-//    @DeleteMapping("/rooms/{sessionid}")
-    //todo test
     @PostMapping("/rooms/{sessionid}/delete")
     public ResponseEntity<PrivateResponseBody> outRoomUser(@PathVariable(name = "sessionid") String sessionId,
                                                            @Authenticated OAuth2UserInfoAuthentication authentication) {
-        log.info("@@방 나가기 API 시작!");
         User user = (User) authentication.getPrincipal();
 
-        log.info("@@방 나가기 API 끝!");
         return new ResponseUtil<>().forDeletedSuccess(chatRoomService.outRoomUser(sessionId, user));
     }
 
@@ -96,10 +92,8 @@ public class ChatRoomController {
     @DeleteMapping("/rooms/{sessionid}")
     public ResponseEntity<PrivateResponseBody> outClickRoomUser(@PathVariable(name = "sessionid") String sessionId,
                                                            @Authenticated OAuth2UserInfoAuthentication authentication) {
-        log.info("@@방 나가기 API 시작!");
         User user = (User) authentication.getPrincipal();
 
-        log.info("@@방 나가기 API 끝!");
         return new ResponseUtil<>().forDeletedSuccess(chatRoomService.outRoomUser(sessionId, user));
     }
 

--- a/src/main/java/shop/dodotalk/dorundorun/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/shop/dodotalk/dorundorun/chatroom/repository/ChatRoomRepository.java
@@ -59,6 +59,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
             Pageable pageable);
 
 
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<ChatRoom> findBySessionIdAndIsDelete(String chatRoomId, boolean isDelete);
 
 

--- a/src/main/java/shop/dodotalk/dorundorun/chatroom/service/ChatRoomScheduler.java
+++ b/src/main/java/shop/dodotalk/dorundorun/chatroom/service/ChatRoomScheduler.java
@@ -1,0 +1,128 @@
+package shop.dodotalk.dorundorun.chatroom.service;
+
+import io.openvidu.java.client.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import shop.dodotalk.dorundorun.chatroom.entity.ChatRoom;
+import shop.dodotalk.dorundorun.chatroom.entity.ChatRoomUser;
+import shop.dodotalk.dorundorun.chatroom.repository.ChatRoomRepository;
+import shop.dodotalk.dorundorun.chatroom.repository.ChatRoomUserRepository;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityNotFoundException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomScheduler {
+
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+
+
+    @Value("${OPENVIDU_URL}")
+    private String OPENVIDU_URL;
+
+    @Value("${OPENVIDU_SECRET}")
+    private String OPENVIDU_SECRET;
+
+    private OpenVidu openvidu;
+
+    @PostConstruct
+    public void init() {
+        this.openvidu = new OpenVidu(OPENVIDU_URL, OPENVIDU_SECRET);
+    }
+
+
+    @Async
+    @Scheduled(fixedRate = 300000)/*5분에 1번*/
+    @Transactional
+    public void chatRoomZeroUserDeleteScheduler() throws OpenViduJavaClientException, OpenViduHttpException {
+        /*스케줄러를 사용하여, 무언가 버그로 인하여 삭제되지 않은 채팅방과, 그방에 속한 유저를 정리해주는 코드 입니다.*/
+
+        /*DB에 저장된 삭제되지 않은 모든 채팅방을 불러온다.*/
+        List<ChatRoom> all = chatRoomRepository.findAllByIsDelete(false);
+
+        /*오픈비듀 서버에서 세션(채팅방)정보를 불러온다.*/
+        openvidu.fetch();
+
+        /*DB랑 오픈비듀랑 비교한다.*/
+        for (ChatRoom chatRoom : all) {
+            Session activeSession = openvidu.getActiveSession(chatRoom.getSessionId());
+
+            if (null == activeSession) {
+//                log.info("❌❌ " + chatRoom.getSessionId() + "는 Openvidu에 존재하지않습니다..");
+
+                List<ChatRoomUser> chatRoomUserList
+                        = chatRoomUserRepository.findAllBySessionIdAndIsDelete(chatRoom.getSessionId(), false);
+
+
+                /*해당 채팅방에서 얼마나 있었는지 시간 표시 기능 구현*/
+                /*방에서 나간 시간 저장.*/
+                LocalDateTime chatRoomExitTime = Timestamp.valueOf(LocalDateTime.now()).toLocalDateTime();
+                LocalTime end = chatRoomExitTime.toLocalTime();
+
+                /*방에서 나갔지만 버그로 인하여 처리가 안되어 안나간것으로 처리되어 있는 유저들*/
+                for (ChatRoomUser chatRoomUser : chatRoomUserList) {
+//                    log.info("❌❌❌ " + chatRoomUser.getNickname() + "는 이미 방에서 나간 유저 입니다. -> 방 나가기 로직을 진행 합니다.");
+
+                    LocalTime start = chatRoomUser.getRoomEnterTime().toLocalTime();
+
+                    /*1.기존에 현재방에서 있었던 시간을 가지고 온다, 처음 입장한 유저 = 00:00:00 */
+                    LocalTime beforeChatRoomStayTime = chatRoomUser.getRoomStayTime().toLocalTime();
+
+                    /*2.현재방에 들어왔던 시간 - 나가기 버튼 누른 시간 = 머문 시간*/
+                    long afterSeconds = ChronoUnit.SECONDS.between(start, end);
+
+                    /*3. 1번의 기존 머문 시간에 + 다시 들어왔을때의 머문시간을 더한다.
+                     * 처음 들어온 유저의 경우 ex) 00:00:00 + 00:05:20  */
+                    /*22.03.03 디자이너님의 요청으로 24시간 넘었을대 1일..2일.. 추가.*/
+                    LocalTime chatRoomStayTime = beforeChatRoomStayTime.plusSeconds(afterSeconds);/*시간 계산*/
+
+                    /*일자 계산*/
+                    int seconds = beforeChatRoomStayTime.toSecondOfDay();
+
+                    Long roomStayDay = chatRoomUser.getRoomStayDay();
+                    if ((seconds + afterSeconds) >= 86400) {/*24시간을 넘기면 1일 추가*/
+                        roomStayDay += 1;
+                    }
+                    /*4. 채팅방 유저 논리 삭제, 방에서 나간 시간 저장, 방에 머문 시간 교체*/
+                    chatRoomUser.deleteRoomUsers(chatRoomExitTime, chatRoomStayTime, roomStayDay);
+                }
+
+
+                /*허구의 방이므로 해당 방 데이터들 삭제!*/
+                /*방 인원 카운트 - 1*/
+                chatRoom.updateCntUser(0L);
+
+                /*방 논리 삭제 + 방 삭제된 시간 기록*/
+                LocalDateTime roomDeleteTime = Timestamp.valueOf(LocalDateTime.now()).toLocalDateTime();
+                chatRoom.deleteRoom(roomDeleteTime);
+                log.info("❌❌❌❌ " + chatRoom.getSessionId() + "는 Openvidu에 존재하지 않는 허구의 방이므로 삭제가 완료 되었습니다.");
+
+
+            } else {
+//                log.info("⭕⭕ " + activeSession.getSessionId() + "는 Openvidu에 존재합니다.");
+            }
+
+        }
+
+
+
+    }
+
+}

--- a/src/main/java/shop/dodotalk/dorundorun/chatroom/service/ChatRoomService.java
+++ b/src/main/java/shop/dodotalk/dorundorun/chatroom/service/ChatRoomService.java
@@ -137,7 +137,7 @@ public class ChatRoomService {
 
         /*페이지네이션 설정 --> 무한 스크롤 예정*/
         PageRequest pageable = PageRequest.of(page - 1, 16);
-        Page<ChatRoom> chatRoomList = chatRoomRepository.findByIsDeleteOrderByModifiedAtDesc(false, pageable);
+        Page<ChatRoom> chatRoomList = chatRoomRepository.findByIsDeleteAndCntUserAfterOrderByModifiedAtDesc(false,0L, pageable);
 
         /*채팅방이 존재하지 않을 경우
          * 프론트 요청으로 빈배열로 보냄.*/
@@ -188,7 +188,7 @@ public class ChatRoomService {
 
         /*비공개 방일 경우, 비밀번호 체크를 수행한다.*/
         if (!chatRoom.isStatus()) {
-            if (requestData == null || requestData.getPassword() == null ) {    // 패스워드를 입력 안했을 때 에러 발생
+            if (requestData == null || requestData.getPassword() == null) {    // 패스워드를 입력 안했을 때 에러 발생
                 throw new IllegalArgumentException("비밀번호를 입력해주세요.");
             }
             if (!chatRoom.getPassword().equals(requestData.getPassword())) {  // 비밀번호가 틀리면 에러 발생
@@ -334,7 +334,7 @@ public class ChatRoomService {
 
         /*방이 있는 지 확인*/
         ChatRoom chatRoom = chatRoomRepository.findBySessionIdAndIsDelete(sessionId, false).orElseThrow(
-                () -> new EntityNotFoundException("방이 존재하지않습니다.")
+                () -> new EntityNotFoundException("채팅방이 존재하지않습니다.")
         );
 
         /*방에 멤버가 존재하는지 확인.*/
@@ -348,10 +348,9 @@ public class ChatRoomService {
         }
 
 
-        /*해당 채팅방에서 얼마나 있었는지 시간 표시 기능 구현
-         * 1. 사용자 입장 -> 프론트 엔드 시계 돌아감 -> 퇴장 시 사용자가 방에 있었던 시간 저장
-         * 2. 다음 입장 시 해당 시간부터 시계 보여줌.*/
 
+
+        /*해당 채팅방에서 얼마나 있었는지 시간 표시 기능 구현*/
 
         /*방에서 나간 시간 저장.*/
         LocalDateTime chatRoomExitTime = Timestamp.valueOf(LocalDateTime.now()).toLocalDateTime();
@@ -431,7 +430,6 @@ public class ChatRoomService {
         String token = session.createConnection(connectionProperties).getToken();
         */
 
-        log.info("!--openvidu 세션 생성 끝");
         return ChatRoomCreateResponseDto.builder()
                 .sessionId(session.getSessionId()) //리턴해주는 해당 세션아이디로 다른 유저 채팅방 입장시 요청해주시면 됩니다.
                 .build();
@@ -459,11 +457,11 @@ public class ChatRoomService {
 
 
         /* 세션 리스트에서 요청자가 입력한 세션 ID가 일치하는 세션을 찾아서 새로운 토큰을 생성
-        * 없다면, Openvidu Server에 해당 방이 존재하지 않는 것이므로, 익셉션 발생 */
+         * 없다면, Openvidu Server에 해당 방이 존재하지 않는 것이므로, 익셉션 발생 */
         Session session = activeSessionList.stream()
                 .filter(s -> s.getSessionId().equals(sessionId))
                 .findFirst()
-                .orElseThrow(() -> new EntityNotFoundException("방이 존재하지 않습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("채팅세션이 존재하지 않습니다."));
 
 
         /*해당 채팅방에 프로퍼티스를 설정하면서 커넥션을 만들고, 방에 접속할 수 있는 토큰을 발급한다.*/
@@ -514,14 +512,15 @@ public class ChatRoomService {
         PageRequest pageable = PageRequest.of(page - 1, 16);
 
         Page<ChatRoom> searchRoom =
-                chatRoomRepository.findByTitleContainingOrSubtitleContainingOrderByModifiedAtDesc(keyword
-                        , keyword
-                        , pageable);
+                chatRoomRepository.findByCntUserAfterAndTitleContainingOrSubtitleContainingOrderByModifiedAtDesc(
+                        0L,
+                        keyword,
+                        keyword,
+                        pageable);
 
         /*검색 결과가 없다면*/
         /* 프론트 요청으로 빈배열로 보냄.*/
         if (searchRoom.isEmpty()) {
-
             return new ChatRoomGetAllResponseDto(new ArrayList<>(), null);
         }
 
@@ -555,7 +554,7 @@ public class ChatRoomService {
         PageRequest pageable = PageRequest.of(page - 1, 16);
 
         Page<ChatRoom> searchRoom =
-                chatRoomRepository.findByIsDeleteAndCategoryOrderByModifiedAtDesc(false, category, pageable);
+                chatRoomRepository.findByIsDeleteAndCategoryAndCntUserAfterOrderByModifiedAtDesc(false, category, 0L, pageable);
 
 
         /*검색 결과가 없다면*/
@@ -591,7 +590,7 @@ public class ChatRoomService {
     public ChatRoomGetAllResponseDto getAllHistoryChatRooms(int page, User user) {
 
         PageRequest pageable = PageRequest.of(page - 1, 16);
-        Page<ChatRoom> chatRoomList = chatRoomRepository.findByUserIdAndIsDelete(user.getId(), true, false, pageable);
+        Page<ChatRoom> chatRoomList = chatRoomRepository.findByUserIdAndIsDelete(user.getId(), true, false, 0L, pageable);
 
 
         /*채팅방이 존재하지 않을 경우
@@ -633,6 +632,7 @@ public class ChatRoomService {
                         user.getId(),
                         true,
                         false,
+                        0L,
                         pageable);
 
         /*검색 결과가 없다면*/

--- a/src/main/java/shop/dodotalk/dorundorun/chatroom/service/ChatRoomService.java
+++ b/src/main/java/shop/dodotalk/dorundorun/chatroom/service/ChatRoomService.java
@@ -384,26 +384,23 @@ public class ChatRoomService {
 
         /* 채팅방 유저 수 확인
          * 채팅방 유저가 0명이라면 방 논리삭제. */
-        Long cntUsers = chatRoom.getCntUser();
-
-        if ((cntUsers - 1) <= 0) {
-            /*방 논리 삭제 + 방 삭제된 시간 기록*/
-            LocalDateTime roomDeleteTime = Timestamp.valueOf(LocalDateTime.now()).toLocalDateTime();
-            chatRoom.deleteRoom(roomDeleteTime);
-
-            /*방인원 0명으로.*/
+        synchronized (chatRoom) {
+            /*방 인원 카운트 - 1*/
             chatRoom.updateCntUser(chatRoom.getCntUser() - 1);
 
+            if (chatRoom.getCntUser() <= 0) {
+                /*방 논리 삭제 + 방 삭제된 시간 기록*/
+                LocalDateTime roomDeleteTime = Timestamp.valueOf(LocalDateTime.now()).toLocalDateTime();
+                chatRoom.deleteRoom(roomDeleteTime);
+                return "Success";
+            }
+
+            /*채팅방의 유저 수가 1명 이상있다면 유저 수만 변경*/
             return "Success";
+
         }
 
-        /*
-        채팅방의 유저 수가 1명 이상 있다면,
-        룸의 유저 수 변경
-        */
-        chatRoom.updateCntUser(chatRoom.getCntUser() - 1);
 
-        return "Success";
     }
 
 

--- a/src/main/java/shop/dodotalk/dorundorun/chatroom/service/SchedulerConfig.java
+++ b/src/main/java/shop/dodotalk/dorundorun/chatroom/service/SchedulerConfig.java
@@ -1,0 +1,29 @@
+package shop.dodotalk.dorundorun.chatroom.service;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class SchedulerConfig implements AsyncConfigurer, SchedulingConfigurer {
+
+    public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(Runtime.getRuntime().availableProcessors() * 2);
+        scheduler.setThreadNamePrefix("OPENVIDU-SCHEDULER-");
+        scheduler.initialize();
+        return scheduler;
+        }
+
+@Override
+public Executor getAsyncExecutor() { return this.threadPoolTaskScheduler(); }
+
+@Override
+public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setTaskScheduler(this.threadPoolTaskScheduler());
+        }
+        }


### PR DESCRIPTION
- 실제로 방에 인원이 존재하지 않지만, 무언가 버그로 인해 인원이 있는 것으로 간주하여 존재하는 허구의 방을 스케줄러로 5분에 한번씩 삭제하는 기능 구현
- 채팅방 목록, 채팅방 검색, 채팅방 카테고리 검색, 히스토리 채팅방 목록, 히스토리 채팅방 검색에서 0명인 방은 보이지 않도록 수정
- 채팅방 나가기 API 동시성 이슈 개선
- 코드 정리